### PR TITLE
Update requirements.txt to include langchain_community

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 streamlit
 boto3
 langchain
+langchain_community


### PR DESCRIPTION
 langchain_community wasn't included initially which create an error loading the module in app.py

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
